### PR TITLE
Fully simulate driving around

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -3,7 +3,6 @@ package frc.robot;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 import edu.wpi.first.cameraserver.CameraServer;
-import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.GenericHID;
@@ -85,9 +84,9 @@ public class RobotContainer {
             () -> {
               System.out.println("Starting PhotonSim");
               while (true) {
-                PhotonSim.update(new Pose2d());
+                PhotonSim.update(driveSubsystem.getPose());
                 // I do not want to use a busy loop, so I added a delay.
-                Timer.delay(0.2);
+                Timer.delay(0.05);
               }
             },
             "simThread");

--- a/src/main/java/frc/robot/simulationSystems/PhotonSim.java
+++ b/src/main/java/frc/robot/simulationSystems/PhotonSim.java
@@ -2,7 +2,7 @@ package frc.robot.simulationSystems;
 
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Transform3d;
+import frc.robot.Constants.CameraConstants.PiCamera;
 import frc.robot.subsystems.PhotonCameraSystem;
 import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.VisionSystemSim;
@@ -14,7 +14,7 @@ public class PhotonSim {
   public static void setupSim() {
     cameraSim = new PhotonCameraSim(PhotonCameraSystem.getCamera());
     visionSim = new VisionSystemSim(cameraSim.getCamera().getName());
-    visionSim.addCamera(cameraSim, new Transform3d());
+    visionSim.addCamera(cameraSim, PiCamera.robotToCam);
     visionSim.addAprilTags(AprilTagFields.k2024Crescendo.loadAprilTagLayoutField());
   }
 

--- a/src/main/java/frc/robot/simulationSystems/SwerveGyroSimulation.java
+++ b/src/main/java/frc/robot/simulationSystems/SwerveGyroSimulation.java
@@ -1,0 +1,63 @@
+package frc.robot.simulationSystems;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.Timer;
+import frc.robot.Constants.DriveConstants.SwerveModuleConstants;
+
+public class SwerveGyroSimulation {
+
+  /** Main timer to control movement estimations. */
+  private final Timer timer;
+
+  /** The last time the timer was read, used to determine position changes. */
+  private double lastTime;
+
+  /** Heading of the robot. */
+  private double angle;
+
+  /** Create the swerve drive IMU simulation. */
+  public SwerveGyroSimulation() {
+    timer = new Timer();
+    timer.start();
+    lastTime = timer.get();
+  }
+
+  /**
+   * Gets the estimated gyro {@link Rotation3d} of the robot.
+   *
+   * @return The heading as a {@link Rotation3d} angle
+   */
+  public Rotation3d getGyroRotation3d() {
+    return new Rotation3d(0, 0, angle);
+  }
+
+  /**
+   * Update the odometry of the simulated swerve drive
+   *
+   * @param kinematics {@link SwerveDriveKinematics} of the swerve drive.
+   * @param states {@link SwerveModuleState} array of the module states.
+   */
+  public void updateOdometry(SwerveModuleState[] states) {
+
+    angle +=
+        SwerveModuleConstants.kDriveKinematics.toChassisSpeeds(states).omegaRadiansPerSecond
+            * (timer.get() - lastTime);
+    lastTime = timer.get();
+  }
+
+  public Rotation2d getRotation2d() {
+    return Rotation2d.fromRadians(angle);
+  }
+
+  /**
+   * Set the heading of the robot.
+   *
+   * @param angle Angle of the robot in radians.
+   */
+  public void setAngle(double angle) {
+    this.angle = angle;
+  }
+}

--- a/src/main/java/frc/robot/simulationSystems/SwerveModuleSim.java
+++ b/src/main/java/frc/robot/simulationSystems/SwerveModuleSim.java
@@ -1,0 +1,78 @@
+package frc.robot.simulationSystems;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import frc.robot.Constants.ModuleConstants;
+
+public class SwerveModuleSim {
+  /** Main timer to simulate the passage of time. */
+  private final Timer timer;
+
+  /** Time delta since last update */
+  private double dt;
+
+  /** Fake motor position. */
+  private double fakePos;
+
+  /**
+   * The fake speed of the previous state, used to calculate {@link SwerveModuleSimulation#fakePos}.
+   */
+  private double fakeSpeed;
+
+  /** Last time queried. */
+  private double lastTime;
+
+  /** Current simulated swerve module state. */
+  private SwerveModuleState state;
+
+  private DCMotorSim driveMotorSim =
+      new DCMotorSim(DCMotor.getNEO(1), ModuleConstants.kDrivingMotorReduction, 0.025);
+
+  public SwerveModuleSim() {
+    timer = new Timer();
+    timer.start();
+    lastTime = timer.get();
+    state = new SwerveModuleState(0, Rotation2d.fromDegrees(0));
+    fakeSpeed = 0;
+    fakePos = 0;
+    dt = 0;
+  }
+
+  /**
+   * Update the position and state of the module.
+   *
+   * <p>WARNING: need to be called periodically for simulation to work correctly.
+   *
+   * @param desiredState State the swerve module should be set to.
+   */
+  public void updateStateAndPosition(SwerveModuleState desiredState) {
+    dt = timer.get() - lastTime;
+    lastTime = timer.get();
+
+    state = desiredState;
+    fakeSpeed = desiredState.speedMetersPerSecond;
+    fakePos += (fakeSpeed * dt);
+  }
+
+  /**
+   * Get the simulated swerve module position.
+   *
+   * @return {@link SwerveModulePosition} of the simulated module.
+   */
+  public SwerveModulePosition getPosition() {
+    return new SwerveModulePosition(fakePos, state.angle);
+  }
+
+  /**
+   * Get the {@link SwerveModuleState} of the simulated module.
+   *
+   * @return {@link SwerveModuleState} of the simulated module.
+   */
+  public SwerveModuleState getState() {
+    return state;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -30,6 +30,7 @@ import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.DriveConstants.MotorConstants;
 import frc.robot.Constants.DriveConstants.SwerveModuleConstants;
 import frc.robot.Constants.OIConstants;
+import frc.robot.simulationSystems.SwerveGyroSimulation;
 import frc.utils.ExtraFunctions;
 import frc.utils.SwerveUtils;
 import java.util.Optional;
@@ -73,6 +74,9 @@ public class DriveSubsystem extends SubsystemBase implements AutoCloseable {
   private SlewRateLimiter magLimiter = new SlewRateLimiter(DriveConstants.kMagnitudeSlewRate);
   private SlewRateLimiter rotLimiter = new SlewRateLimiter(DriveConstants.kRotationalSlewRate);
   private double prevTime = WPIUtilJNI.now() * 1e-6;
+
+  SwerveGyroSimulation gyroSim =
+      new SwerveGyroSimulation(); // required for getRotation2d() in simulation
 
   SwerveDrivePoseEstimator swerveOdometry =
       new SwerveDrivePoseEstimator(
@@ -143,38 +147,26 @@ public class DriveSubsystem extends SubsystemBase implements AutoCloseable {
               rearLeft.getPosition(),
               rearRight.getPosition()
             });
-    field.setRobotPose(pose);
+    Pose2d poseWithRobotGyroRotation = new Pose2d(pose.getTranslation(), getRotation2d());
+    field.setRobotPose(poseWithRobotGyroRotation);
     updatePoseWithVision();
+    gyroSim.updateOdometry(getModuleDesiredStates());
     SmartDashboard.putData(field);
     SmartDashboard.putNumber("Rotation", getHeading());
     SmartDashboard.putBoolean("Force Robot Oriented", forceRobotOriented);
-    if (RobotBase.isReal()) {
-      publisher.set(
-          new SwerveModuleState[] {
-            frontLeft.getState(), frontRight.getState(), rearLeft.getState(), rearRight.getState(),
-          });
-    }
-  }
 
-  @Override
-  public void simulationPeriodic() {
-    var states = getModuleDesiredStates();
-    publisher.set(states);
-    SmartDashboard.putNumber("Front Left Swerve Speed", states[0].speedMetersPerSecond);
-    SmartDashboard.putNumber("Front Left Swerve Rotation", states[0].angle.getDegrees());
-    SmartDashboard.putNumber("Front Right Swerve Speed", states[1].speedMetersPerSecond);
-    SmartDashboard.putNumber("Front Right Swerve Rotation", states[1].angle.getDegrees());
-    SmartDashboard.putNumber("Rear Left Swerve Speed", states[2].speedMetersPerSecond);
-    SmartDashboard.putNumber("Rear Left Swerve Rotation", states[2].angle.getDegrees());
-    SmartDashboard.putNumber("Rear Right Swerve Speed", states[3].speedMetersPerSecond);
-    SmartDashboard.putNumber("Rear Right Swerve Rotation", states[3].angle.getDegrees());
+    publisher.set(
+        new SwerveModuleState[] {
+          frontLeft.getState(), frontRight.getState(), rearLeft.getState(), rearRight.getState(),
+        });
 
-    var xPos = SmartDashboard.getNumber("X position", 0);
-    var yPos = SmartDashboard.getNumber("Y position", 0);
-
-    if (xPos != 0 && yPos != 0) {
-      resetOdometry(new Pose2d(xPos, yPos, getRotation2d()));
-    }
+    field
+        .getObject("XModules")
+        .setPoses(
+            frontLeft.getRealWorldPose(getPose()),
+            frontRight.getRealWorldPose(getPose()),
+            rearLeft.getRealWorldPose(getPose()),
+            rearRight.getRealWorldPose(getPose()));
   }
 
   @Override
@@ -191,10 +183,21 @@ public class DriveSubsystem extends SubsystemBase implements AutoCloseable {
     closeNavX();
   }
 
+  /**
+   * Closes the navX with Reflection shenanigans. I couldn't find a way to close the navX without
+   * reflection, so I had to use reflection to access the private field and close it.
+   *
+   * <p>WARNING: This method is not guaranteed to work on all platforms, and may not work on macOS.
+   * This method is only used for testing and simulation purposes, and should not be used in a
+   * competition robot.
+   *
+   * <p>This method is not required when simulating in windows, but is required for linux. macOS is
+   * untested.
+   */
   private void closeNavX() {
     try {
       var sd = AHRS.class.getDeclaredField("m_simDevice");
-      sd.setAccessible(true);
+      sd.setAccessible(true); // NOSONAR
       var amazing = (SimDevice) sd.get(navX);
       amazing.close();
     } catch (Exception e) {
@@ -251,12 +254,15 @@ public class DriveSubsystem extends SubsystemBase implements AutoCloseable {
 
     if (tag.isEmpty()) return new Rotation2d();
 
-    return tag.get()
-        .getTranslation() // Get the translation of the tag
-        .toTranslation2d()
-        .minus(getPose().getTranslation()) // Subtract the robot's translation
-        .getAngle()
-        .minus(getRotation2d()) // Subtract the robot's rotation
+    Rotation2d robotFontsRotationDifferenceToShooter =
+        tag.get()
+            .getTranslation() // Get the translation of the tag
+            .toTranslation2d()
+            .minus(getPose().getTranslation()) // Subtract the robot's translation
+            .getAngle()
+            .minus(getRotation2d()); // Subtract the robot's rotation
+
+    return robotFontsRotationDifferenceToShooter
         .rotateBy(Rotation2d.fromDegrees(180)) // Rotate by 180 so the back is 0
         .times(-1); // Invert the angle, so the back is a positive angle that can be inverted.
   }
@@ -466,6 +472,9 @@ public class DriveSubsystem extends SubsystemBase implements AutoCloseable {
   }
 
   public Rotation2d getRotation2d() {
+    if (RobotBase.isSimulation() && navX.getAngle() == 0) {
+      return gyroSim.getRotation2d();
+    }
     return navX.getRotation2d();
   }
 

--- a/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
@@ -6,10 +6,14 @@ import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkAbsoluteEncoder.Type;
 import com.revrobotics.SparkPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.RobotBase;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.ModuleConstants;
+import frc.robot.simulationSystems.SwerveModuleSim;
 import frc.utils.sim_utils.CANSparkMAXWrapped;
 
 public class MAXSwerveModule implements AutoCloseable {
@@ -24,6 +28,12 @@ public class MAXSwerveModule implements AutoCloseable {
 
   private double m_chassisAngularOffset = 0;
   private SwerveModuleState m_desiredState = new SwerveModuleState(0.0, new Rotation2d());
+
+  /* SIM RELATED OBJECTS */
+
+  private final SwerveModuleSim driveSim = new SwerveModuleSim();
+
+  /* END SIM RELATED OBJECTS */
 
   /**
    * Constructs a MAXSwerveModule and configures the driving and turning motor, encoder, and PID
@@ -118,6 +128,9 @@ public class MAXSwerveModule implements AutoCloseable {
    * @return The current state of the module.
    */
   public SwerveModuleState getState() {
+    if (RobotBase.isSimulation()) {
+      return driveSim.getState();
+    }
     // Apply chassis angular offset to the encoder position to get the position
     // relative to the chassis.
     return new SwerveModuleState(
@@ -131,6 +144,9 @@ public class MAXSwerveModule implements AutoCloseable {
    * @return The current position of the module.
    */
   public SwerveModulePosition getPosition() {
+    if (RobotBase.isSimulation()) {
+      return driveSim.getPosition();
+    }
     // Apply chassis angular offset to the encoder position to get the position
     // relative to the chassis.
     return new SwerveModulePosition(
@@ -144,6 +160,8 @@ public class MAXSwerveModule implements AutoCloseable {
    * @param desiredState Desired state with speed and angle.
    */
   public void setDesiredState(SwerveModuleState desiredState) {
+    driveSim.updateStateAndPosition(desiredState);
+
     // Apply chassis angular offset to the desired state.
     SwerveModuleState correctedDesiredState = new SwerveModuleState();
     correctedDesiredState.speedMetersPerSecond = desiredState.speedMetersPerSecond;
@@ -171,5 +189,24 @@ public class MAXSwerveModule implements AutoCloseable {
   /** Zeroes all the SwerveModule encoders. */
   public void resetEncoders() {
     m_drivingEncoder.setPosition(0);
+  }
+
+  public Pose2d getRealWorldPose(Pose2d robotPose) {
+    Pose2d moduleOffsetPose = getPoseDiffToRobot();
+
+    return new Pose2d(
+        robotPose.getX() + moduleOffsetPose.getX(),
+        robotPose.getY() + moduleOffsetPose.getY(),
+        getPosition().angle);
+  }
+
+  private Pose2d getPoseDiffToRobot() {
+    var moduleRotationOffset = Rotation2d.fromRadians(m_chassisAngularOffset);
+    var moduleOffsetLength = DriveConstants.kWheelBase / 2.0;
+
+    return new Pose2d(
+        moduleRotationOffset.getCos() * moduleOffsetLength,
+        moduleRotationOffset.getSin() * moduleOffsetLength,
+        moduleRotationOffset);
   }
 }

--- a/src/test/java/subsystem_tests/drive_subsystem_tests/DriveSubsystemTestBase.java
+++ b/src/test/java/subsystem_tests/drive_subsystem_tests/DriveSubsystemTestBase.java
@@ -25,9 +25,9 @@ public class DriveSubsystemTestBase {
 
   @AfterEach
   public void tearDown() {
-    driveSubsystem.close();
     commandScheduler.cancelAll();
     commandScheduler.unregisterAllSubsystems(); // ! breaks all test tests if not done
+    driveSubsystem.close();
     commandScheduler.close();
   }
 }

--- a/src/test/java/subsystem_tests/drive_subsystem_tests/DriveWithGyroTests.java
+++ b/src/test/java/subsystem_tests/drive_subsystem_tests/DriveWithGyroTests.java
@@ -2,7 +2,6 @@ package subsystem_tests.drive_subsystem_tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import edu.wpi.first.hal.simulation.SimDeviceDataJNI;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.Timer;
 import frc.robot.Constants.DriveConstants;
@@ -21,14 +20,6 @@ class DriveWithGyroTests extends DriveSubsystemTestBase {
   @AfterEach
   public void tearDown() {
     super.tearDown();
-  }
-
-  @Test
-  void printAllSimNames() {
-    for (int i = 1; i <= 16; i++) {
-      var deviceName = SimDeviceDataJNI.getSimDeviceName(i);
-      System.out.println(deviceName);
-    }
   }
 
   @Test

--- a/src/test/java/subsystem_tests/drive_subsystem_tests/PeriodicTests.java
+++ b/src/test/java/subsystem_tests/drive_subsystem_tests/PeriodicTests.java
@@ -1,12 +1,16 @@
 package subsystem_tests.drive_subsystem_tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.Constants.DriveConstants.SwerveModuleConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,25 +27,6 @@ class PeriodicTests extends DriveSubsystemTestBase {
   }
 
   @Test
-  void testSimulationPeriodic() {
-    driveSubsystem.driveRobotRelative(new ChassisSpeeds(2, 0, 0));
-    driveSubsystem.simulationPeriodic();
-
-    assertEquals(2, SmartDashboard.getNumber("Front Left Swerve Speed", 0));
-    assertEquals(2, SmartDashboard.getNumber("Front Right Swerve Speed", 0));
-    assertEquals(2, SmartDashboard.getNumber("Rear Left Swerve Speed", 0));
-    assertEquals(2, SmartDashboard.getNumber("Rear Right Swerve Speed", 0));
-
-    driveSubsystem.driveRobotRelative(new ChassisSpeeds(0, 2, 0));
-    driveSubsystem.simulationPeriodic();
-
-    assertEquals(90, SmartDashboard.getNumber("Front Left Swerve Rotation", 0));
-    assertEquals(90, SmartDashboard.getNumber("Front Right Swerve Rotation", 0));
-    assertEquals(90, SmartDashboard.getNumber("Rear Left Swerve Rotation", 0));
-    assertEquals(90, SmartDashboard.getNumber("Rear Right Swerve Rotation", 0));
-  }
-
-  @Test
   void testPeriodic() {
     driveSubsystem.resetOdometry(new Pose2d(3, 2, Rotation2d.fromDegrees(30)));
 
@@ -51,5 +36,34 @@ class PeriodicTests extends DriveSubsystemTestBase {
     assertEquals(Rotation2d.fromDegrees(30), field.getRobotPose().getRotation());
     assertEquals(3, field.getRobotPose().getTranslation().getX());
     assertEquals(2, field.getRobotPose().getTranslation().getY());
+  }
+
+  @Test
+  void testPeriodicSwerveStateSending() {
+    var entry =
+        NetworkTableInstance.getDefault()
+            .getStructArrayTopic("Swerve", SwerveModuleState.struct)
+            .subscribe(new SwerveModuleState[4]);
+
+    ChassisSpeeds speedsToGo = new ChassisSpeeds(1, 0, 0);
+    driveSubsystem.driveRobotRelative(speedsToGo);
+
+    driveSubsystem.periodic();
+
+    NetworkTableInstance.getDefault().waitForListenerQueue(-1);
+
+    var states = entry.get();
+
+    assertNotNull(states[0]);
+    var receivedSpeeds =
+        SwerveModuleConstants.kDriveKinematics.toChassisSpeeds(
+            new SwerveModuleState[] {states[0], states[1], states[2], states[3]});
+
+    // Until 2025, ChassisSpeeds equals check is not implemented we'll compare each value separately
+    // See: https://github.com/wpilibsuite/allwpilib/pull/6414
+    // do this in 2025: {assertEquals(speedsToGo, receivedSpeeds);}
+    assertEquals(speedsToGo.vxMetersPerSecond, receivedSpeeds.vxMetersPerSecond, 0.01);
+    assertEquals(speedsToGo.vyMetersPerSecond, receivedSpeeds.vyMetersPerSecond, 0.01);
+    assertEquals(speedsToGo.omegaRadiansPerSecond, receivedSpeeds.omegaRadiansPerSecond, 0.01);
   }
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the simulation capabilities and improve the code structure. The most important changes include the addition of new simulation classes, updates to existing simulation methods, and improvements to the `DriveSubsystem` and `MAXSwerveModule` classes to better support simulation.

### Copied and modified classes for our fit from [YAGSL example](https://github.com/BroncBotz3481/YAGSL-Example/tree/dev/src/main/java/swervelib/simulation)

* Added [`SwerveGyroSimulation`](https://github.com/BroncBotz3481/YAGSL-Example/blob/dev/src/main/java/swervelib/simulation/SwerveIMUSimulation.java) class to simulate the swerve drive IMU.
* Added [`SwerveModuleSim`](https://github.com/BroncBotz3481/YAGSL-Example/blob/dev/src/main/java/swervelib/simulation/SwerveModuleSimulation.java) class to simulate the swerve module state and position.

### Simulation Enhancements:

the simulated position. (`src/main/java/frc/robot/simulationSystems/SwerveModuleSim.java`)
* Integrated `SwerveGyroSimulation` into `DriveSubsystem` for better simulation support, including updates to the periodic method and new methods for handling rotation. (`src/main/java/frc/robot/subsystems/DriveSubsystem.java`)
* Updated `DriveSubsystem` to use vision measurements for pose estimation, ensuring more reliable data by ignoring rotation from the vision system. (`src/main/java/frc/robot/subsystems/DriveSubsystem.java`)

* Integrated `SwerveModuleSim` into `MAXSwerveModule` to simulate module state and position.

### Bug Fixes

* Modified `PhotonSim` setup to use `PiCamera.robotToCam` for camera simulation. (was forgotten to do so before this)
* Used `driveSubsystem` pose in the PhotonSim Update instead of creating a new one constantly